### PR TITLE
Wrong partitition used, allow use of 'by-partuuid'

### DIFF
--- a/alez.sh
+++ b/alez.sh
@@ -11,9 +11,11 @@ fi
 # Set a default locale during install to avoid mandb error when indexing man pages
 export LANG=C
 
+installdir="/mnt"
+
 # Run stuff in the ZFS chroot install function
 chrun() {
-	arch-chroot /mnt /bin/bash -c "$1"
+	arch-chroot $installdir /bin/bash -c "$1"
 }
 
 # List and enumerate attached disks function
@@ -48,13 +50,17 @@ while [ "$dopart" == "y" ] || [ "$dopart" == "Y" ]; do
   read -p "Do you want to partition another device? (N/y) : " dopart
 done
 
+echo "Partition layout:"
+lsblk
+
 echo -e "Available partitions:\n\n"
 
 # Read partitions into an array and print enumerated
-partids=(`ls /dev/disk/by-id/*`)
+partids=($(ls /dev/disk/by-id/* /dev/disk/by-partuuid/*))
 ptcount=${#partids[@]}
+
 for (( p=0; p<${ptcount}; p++ )); do
-   echo -e "$p - ${partids[p]}\n"
+   echo -e "$p - ${partids[p]} -> $(readlink ${partids[p]})\n"
 done
 
 # Try exporting zroot pool in case previous installation attempt failed
@@ -96,30 +102,30 @@ zfs create -o mountpoint=/home zroot/data/home
 zfs umount -a
 
 echo "Setting ZFS mount options..."
-zfs set mountpoint=/ zroot/ROOT/default
+zfs set mountpoint=/ zroot/ROOT/default &> /dev/null
 zfs set mountpoint=legacy zroot/data/home
 zfs set atime=off zroot
 zpool set bootfs=zroot/ROOT/default zroot
 
 echo "Exporting and importing pool..."
 zpool export zroot
-zpool import `zpool import | grep id: | awk '{print $2}'` -R /mnt zroot
+zpool import `zpool import | grep id: | awk '{print $2}'` -R ${installdir} zroot
 
 echo "Installing Arch base system..."
-pacstrap /mnt base
+pacstrap ${installdir} base
 
 #echo "Copy zpool.cache..."
-#mkdir /mnt/etc/zfs
-#cp /etc/zfs/zpool.cache /mnt/etc/zfs
+#mkdir ${installdir}/etc/zfs
+#cp /etc/zfs/zpool.cache ${installdir}/etc/zfs
 
 echo "Add fstab entries..."
-echo -e "zroot/ROOT/default / zfs defaults,noatime 0 0\nzroot/data/home /home zfs defaults,noatime 0 0" >> /mnt/etc/fstab
+echo -e "zroot/ROOT/default / zfs defaults,noatime 0 0\nzroot/data/home /home zfs defaults,noatime 0 0" >> ${installdir}/etc/fstab
 
 echo "Add Arch ZFS pacman repo..."
-echo -e "\n[archzfs]\nServer = http://archzfs.com/\$repo/x86_64" >> /mnt/etc/pacman.conf
+echo -e "\n[archzfs]\nServer = http://archzfs.com/\$repo/x86_64" >> ${installdir}/etc/pacman.conf
 
 echo "Modify HOOKS in mkinitcpio.conf..."
-sed -i 's/HOOKS=.*/HOOKS="base udev autodetect modconf block keyboard zfs filesystems"/g' /mnt/etc/mkinitcpio.conf
+sed -i 's/HOOKS=.*/HOOKS="base udev autodetect modconf block keyboard zfs filesystems"/g' ${installdir}/etc/mkinitcpio.conf
 
 echo "Adding Arch ZFS repo key in chroot..."
 chrun "pacman-key -r F75D9D76; pacman-key --lsign-key F75D9D76"
@@ -129,7 +135,7 @@ chrun "pacman -Sy; pacman -S --noconfirm zfs-linux grub os-prober"
 
 echo "Adding Arch ZFS entry to GRUB menu..."
 awk -i inplace '/10_linux/ && !x {print $0; print "menuentry \"Arch Linux ZFS\" {\n\tlinux /ROOT/default/@/boot/vmlinuz-linux \
-	zfs=zroot/ROOT/default rw\n\tinitrd /ROOT/default/@/boot/initramfs-linux.img\n}"; x=1; next} 1' /mnt/boot/grub/grub.cfg
+	zfs=zroot/ROOT/default rw\n\tinitrd /ROOT/default/@/boot/initramfs-linux.img\n}"; x=1; next} 1' ${installdir}/boot/grub/grub.cfg
 echo "Update initial ramdisk (initrd) with ZFS support..."
 chrun "mkinitcpio -p linux"
 
@@ -137,11 +143,12 @@ echo -e "Enable systemd ZFS service...\n"
 chrun "systemctl enable zfs.target"
 
 # Write script to create symbolic links for partition ids to work around a GRUB bug that can cause grub-install to fail - hackety hack
-echo -e "ptids=(\`cd /dev/disk/by-id/;ls\`)\nidcount=\${#ptids[@]}\nfor (( c=0; c<\${idcount}; c++ )) do\ndevs[c]=\$(readlink /dev/disk/by-id/\${ptids[\$c]} | sed 's/\.\.\/\.\.\///')\nln -s /dev/\${devs[c]} /dev/\${ptids[c]}\ndone" > /mnt/home/partlink.sh
+echo -e "ptids=(\`cd /dev/disk/by-id/;ls\`)\nidcount=\${#ptids[@]}\nfor (( c=0; c<\${idcount}; c++ )) do\ndevs[c]=\$(readlink /dev/disk/by-id/\${ptids[\$c]} | sed 's/\.\.\/\.\.\///')\nln -s /dev/\${devs[c]} /dev/\${ptids[c]}\ndone" > ${installdir}/home/partlink.sh
+echo -e "ptids=(\`cd /dev/disk/by-partuuid/;ls\`)\nidcount=\${#ptids[@]}\nfor (( c=0; c<\${idcount}; c++ )) do\ndevs[c]=\$(readlink /dev/disk/by-partuuid/\${ptids[\$c]} | sed 's/\.\.\/\.\.\///')\nln -s /dev/\${devs[c]} /dev/\${ptids[c]}\ndone" >> ${installdir}/home/partlink.sh
 
 echo -e "Create symbolic links for partition ids to work around a grub-install bug...\n"
 chrun "sh /home/partlink.sh"
-rm -f /mnt/home/partlink.sh
+rm -f ${installdir}/home/partlink.sh
 
 lsdsks
 

--- a/alez.sh
+++ b/alez.sh
@@ -107,6 +107,18 @@ zfs set mountpoint=legacy zroot/data/home
 zfs set atime=off zroot
 zpool set bootfs=zroot/ROOT/default zroot
 
+if [ "$(ls -A ${installdir})" ]; then
+    echo "Install directory ${installdir} isn't empty"
+    tempdir="$(mktemp -d)"
+    if [ -d "${tempdir}" ]; then
+        echo "Using temp directory ${tempdir}"
+        installdir="${tempdir}"
+    else
+        echo "Exiting, error occurred"
+        exit 1
+    fi
+fi
+
 echo "Exporting and importing pool..."
 zpool export zroot
 zpool import `zpool import | grep id: | awk '{print $2}'` -R ${installdir} zroot


### PR DESCRIPTION
After attempting to run `alez`, it looks like the pool isn't properly created, the script continues and installs directly to the install media in `/mnt`, eventually using up all the space on the device.

<details><summary>This is what I got at install</summary><p>

```
Arch Linux Easy ZFS (ALEZ) installer 0.33

By Dan MacDonald 2016-2018


Please make sure you are connected to the Internet before running ALEZ.


Do you want to select a drive to be auto-partitioned? (N/y): y
NAME   MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
loop0    7:0    0 469.5M  1 loop /run/archiso/sfs/airootfs
sr0     11:0    1   581M  0 rom  /run/archiso/bootmnt
vda    254:0    0    40G  0 disk 
|-vda1 254:1    0     1M  0 part 
`-vda2 254:2    0    40G  0 part 

Attached disks : 

0 - vda

Enter the number of the disk you want to partition, between 0 and 0 : 0
ALL data on /dev/vda will be lost? Proceed? (N/y) : y
GPT partitioning /dev/vda...
Do you want to partition another device? (N/y) : N
Available partitions:


0 - /dev/disk/by-id/ata-QEMU_DVD-ROM_QM00002

If you used this script to create your partitions, choose partitions ending with -part2


Do you want to create a single or double disk (mirrored) zpool? (1/2) : 1
Enter the number of the partition above that you want to create a new zpool on : 0
Creating a single disk zpool...
cannot open '/dev/disk/by-id/ata-QEMU_DVD-ROM_QM00002': Device or resource busy
cannot create 'zroot': one or more vdevs refer to the same device, or one of
the devices is part of an active md or lvm device
Creating datasets...
cannot create 'zroot/data': no such pool 'zroot'
cannot create 'zroot/ROOT': no such pool 'zroot'
cannot create 'zroot/ROOT/default': no such pool 'zroot'
cannot create 'zroot/data/home': no such pool 'zroot'
Setting ZFS mount options...
cannot open 'zroot/ROOT/default': dataset does not exist
cannot open 'zroot/data/home': dataset does not exist
cannot open 'zroot': dataset does not exist
cannot open 'zroot': no such pool
Exporting and importing pool...
```
</p></details>

---

It seems to be doing this because sometimes `/dev/disk/by-id` will not have an ID for all partitions. This patch will allow use of `/dev/disk/by-partuuid/` IDs to provide another option.

Also include the origin of the symlink of the ID, to help the user decide on the correct partition.

As a byproduct of the failed install, since the install was done directly to the install media. When I went to try again `/mnt` wasn't empty, so mounting the root dataset failed. This patch also uses a temporary directory if `/mnt` is full. f7a8c3dd9ebccfdd35210d1bd632015c9c5d3531

<details><summary>This is the relevant install output from the changes</summary><p>

```
Arch Linux Easy ZFS (ALEZ) installer 0.33

By Dan MacDonald 2016-2018


Please make sure you are connected to the Internet before running ALEZ.


Do you want to select a drive to be auto-partitioned? (N/y): y
NAME   MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
loop0    7:0    0 469.5M  1 loop /run/archiso/sfs/airootfs
sr0     11:0    1   581M  0 rom  /run/archiso/bootmnt
vda    254:0    0    40G  0 disk 
|-vda1 254:1    0     1M  0 part 
`-vda2 254:2    0    40G  0 part 

Attached disks : 

0 - vda

Enter the number of the disk you want to partition, between 0 and 0 : 0
ALL data on /dev/vda will be lost? Proceed? (N/y) : y
GPT partitioning /dev/vda...
Do you want to partition another device? (N/y) : N
Available partitions:


0 - /dev/disk/by-id/ata-QEMU_DVD-ROM_QM00002 -> ../../sr0

1 - /dev/disk/by-partuuid/2e2132cb-5116-4198-b2b9-864777b34d42 -> ../../vda2

2 - /dev/disk/by-partuuid/aba0000f-3461-4261-8373-458a78efa8b7 -> ../../vda1

If you used this script to create your partitions, choose partitions ending with -part2


Do you want to create a single or double disk (mirrored) zpool? (1/2) : 1
Enter the number of the partition above that you want to create a new zpool on : 1
Creating a single disk zpool...
Creating datasets...
cannot mount '/': directory is not empty
filesystem successfully created, but not mounted
Setting ZFS mount options...
Install directory /mnt isn't empty
Using temp directory /tmp/tmp.KUSuReDnKe
Exporting and importing pool...
Installing Arch base system...
```
</p></details>
