### PR TITLE
make BIOS partitioning zap all disk partitions too

### DIFF
--- a/alez.sh
+++ b/alez.sh
@@ -89,10 +89,15 @@ lsparts() {
     done
 }
 
+zap_partition(){
+    vgchange -an &> /dev/null
+    mdadm --zero-superblock --force "${1}" &> /dev/null
+    sgdisk --zap-all "${1}" &> /dev/null
+}
+
 bios_partitioning(){
     echo -e "GPT BIOS partitioning ${1}...\n"
-    mdadm --zero-superblock --force "${1}" &> /dev/null
-
+    zap_partition "${1}"
     parted --script "${1}" \
         mklabel gpt \
         mkpart non-fs 0% 2 \
@@ -101,9 +106,7 @@ bios_partitioning(){
 
 uefi_partitioning(){
     echo -e "GPT UEFI partitioning ${1}...\n"
-
-    mdadm --zero-superblock --force "${1}" &> /dev/null
-    sgdisk --zap-all "${1}"
+    zap_partition "${1}"
 
     echo "Creating EFI partition"
     sgdisk --new="1:1M:+${2}M" --typecode=1:EF00 "${1}"


### PR DESCRIPTION
In my box, and old VG causing `parted` failed to tell kernel to reload the new partition table with error message:

```
Error: Partition(s) 3 on /dev/sda have been written, but we have been unable 
to inform the kernel of the change, probably because it/they are in use.  
As a result, the old partition(s) will remain in use.  
You should reboot now before making further changes.
```

zapping the partition before executing `parted` seems to fix it