### PR TITLE
Auto-build ISO releases with Docker and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: required
+env:
+  global:
+  - DOCKER_TAG=alezbuild
+services:
+- docker
+before_install:
+- docker build -t "$DOCKER_TAG" ./
+script:
+- mkdir out
+- docker run --privileged --volume="/dev:/dev" --volume="$PWD/out:/opt/alez/iso/out" "$DOCKER_TAG"
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+branches:
+  only:
+    - master
+before_deploy:
+  # Set up git user name and tag this commit
+  - git config --local user.name "$(git log -1 $TRAVIS_COMMIT --pretty="%aN")"
+  - git config --local user.email "$(git log -1 $TRAVIS_COMMIT --pretty="%cE")"
+  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+  - git tag $TRAVIS_TAG
+  - export RELEASE_ISO="$(ls out/*)"
+deploy:
+  provider: releases
+  api_key:
+    secure: RmIS2n4YAMQHQWGgkOdYd0NDT/v1x2Lsm3oC0kM3KCsjpDAeqmGDDIcrdukKCSc/NxiQaobMYBR4ox/an/3QwyGZkapRl+q1fKvoSfpuExGKcYuNc3ok+2r3mP3+aqx7jQZyDzryBlGov4IxWLwutahZ3dOFoZfL/tyhZmdn4FkcFHNsVi/JwSq247NUAI36CEbQ9H/hby+j3oQvX26SYCzzob8kfz7nUPX2UZmWfVRmgEbyCZtPR9FRo5SEfsRsTPEdgyP4tCO/dms3swYyL99/eEWnqDJ7dtI5SU0XgHogKg/jwlrnZM4RKCTG0dAv57A9ZCpyGaMUoSn1FUx5aABSUqswcNgKEkSuDKh5auB8u69PqgQpqNjrL6rvJzFklycy5uyfWv44kQgneQ3Znp/DLrW5+QokWwykVUedbbQNPF0WZ68pSbNBHaeawyAeYU2MLHdy0jSQrglXXo0lqnZI+JIaIJ9sA0VO0iRy24LkdrGghCw4Iu427Ak1tdoUK9v4LI0i88f8jfeveuGt6PCJWz7wlnUGK9skYZ8nypOAfPrHeO95lmF9uVe9qp5nvcVVrXjpq2n9KvkzFbrqblxqV4aDisAEUBZRF2dyEK+YOI5Ia6awZTWIqmAvb3hW4F3EHnsEhS9ed2l1VB1lYN+mDvzqhKaGqvLNyrBAsEI=
+  file: "${RELEASE_ISO}"
+  skip_cleanup: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM archlinux/base
+
+ARG ALEZ_BUILD_DIR='/opt/alez'
+ARG ARCHZFS_KEY='F75D9D76'
+
+RUN pacman -Syu --noconfirm --needed base base-devel git archiso
+
+RUN rm -rf /etc/pacman.d/gnupg && \
+    pacman-key --init && pacman-key --populate archlinux && \
+    pacman-key -r "${ARCHZFS_KEY}" && pacman-key --lsign-key "${ARCHZFS_KEY}"
+
+RUN mkdir -p "${ALEZ_BUILD_DIR}" && \
+    cp -r /usr/share/archiso/configs/releng "${ALEZ_BUILD_DIR}/iso" && \
+    mkdir -p "${ALEZ_BUILD_DIR}/iso/out" "${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/bin"
+
+# Add archzfs before [core]
+RUN sed -i '/^\[core\]/i [archzfs]\n\
+            SigLevel = Optional TrustAll\n\
+            Server = http://archzfs.com/$repo/x86_64\n' \
+    "${ALEZ_BUILD_DIR}/iso/pacman.conf"
+
+RUN printf 'git\narchzfs-linux\n' >> "${ALEZ_BUILD_DIR}/iso/packages.x86_64"
+
+COPY alez-downloader.sh "${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/bin/alez"
+COPY motd "${ALEZ_BUILD_DIR}/iso/airootfs/etc/"
+
+RUN chmod +x "${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/bin/alez"
+
+VOLUME "${ALEZ_BUILD_DIR}/iso/out"
+
+WORKDIR "${ALEZ_BUILD_DIR}/iso"
+CMD ["./build.sh", "-v"]


### PR DESCRIPTION
## Automated releases using Travis CI

This pull request implements a `Dockerfile` and `.travis.yml` for auto-building releases, and deploying them on pushes to master.

The `Dockerfile` sets up an Arch Linux container with everything required to build an ISO. It has `alez-downloader.sh`, and the `motd` embedded in the ISO.

### Container

The container can be built with:

    docker build -t "alezbuild" ./

To run the container and build the ISO:

    docker run --privileged \
            --volume="/dev:/dev" \
            --volume="$PWD/out:/opt/alez/iso/out" "alezbuild"

Both `--privileged`, and mounting `/dev` are necessary in order for the container to be able to chroot, and mount a loop-back device.

This can also be used as an easy way to create an ISO, and it doesn't require an arch system. This could be useful for users who are not currently using Arch but would like to create their own ISO.

All the same problems may occur that we have experienced before during the build if the kernel version and zfs version are out of sync.

### Travis CI

The `.travis.yml` mainifest basically does does the above build and run of the container, saving the built ISO to `out/`, and if successful deploying as a new release.

In the current configuration it auto-tags a release in the form:

    TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)

This could be modified to only create a release on tagged commits alternatively.

The configuration could be modified to only create a release on tagged commits alternatively. [`draft: true`](https://docs.travis-ci.com/user/deployment/releases#draft-releases-with-draft-true) could also be used so that the releases are 'internal' to contributors, and releases could be modified before finalized.

The releases are tagged using the committers name and email with:

    git config --local user.name "$(git log -1 $TRAVIS_COMMIT --pretty="%aN")"
    git config --local user.email "$(git log -1 $TRAVIS_COMMIT --pretty="%cE")"

Alternatively the variables could be set to a specific user and email.

For authentication an OAuth key should be [created](https://github.com/settings/tokens/new) with the 'repo' scope so it can push releases to the repo.

After logging in to Travis CI, and creating the token it can be encrypted using the Travis CI gem.

Encrypt it with:

    travis login
    travis encrypt "<TOKEN GOES HERE>"

The token can then be set in the `.travis.yml` under:

    deploy:
    provider: releases
    api_key:
        secure: "<ENCRYPTED TOKEN GOES HERE>"

At this point, if Travis CI is enabled on the repo, pushes should auto build.

## Tests

I've tested auto building and deploying a release on a test github repo. I downloaded the built ISO, and everything is working correctly as far as I could tell.
