### PR TITLE
Use pre-seeded alez clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN pacman-key --init && pacman-key --populate archlinux && \
 RUN mkdir -p "${ALEZ_BUILD_DIR}" && \
     cp -r /usr/share/archiso/configs/releng "${ALEZ_BUILD_DIR}/iso" && \
     sed --in-place '/wpa_actiond/d' "${ALEZ_BUILD_DIR}/iso/packages.x86_64" && \
-    mkdir -p "${ALEZ_BUILD_DIR}/iso/out" "${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/bin"
+    mkdir -p \
+        "${ALEZ_BUILD_DIR}/iso/out" \
+        "${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/bin" \
+        "${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/share"
 
 # Add archzfs before [core]
 RUN sed -i '/^\[core\]/i [archzfs]\n\
@@ -24,6 +27,10 @@ RUN printf 'git\narchzfs-linux\nreflector\n' >> "${ALEZ_BUILD_DIR}/iso/packages.
 
 COPY alez-downloader.sh "${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/bin/alez"
 COPY motd "${ALEZ_BUILD_DIR}/iso/airootfs/etc/"
+
+RUN git clone --branch master --single-branch --depth 1 \
+    https://github.com/danboid/ALEZ.git \
+    ${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/share/ALEZ 
 
 RUN chmod +x "${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/bin/alez"
 


### PR DESCRIPTION
## Summary

Rather than pulling alez every time it's run, I think it makes sense to only clone the repo when there are changes. It would also be useful to do the initial clone during the build of the ISO and have it baked in meaning startup will be faster.

## implementation

Run a shallow clone during the ISO build:

```
git clone --branch master --single-branch --depth 1 https://github.com/danboid/ALEZ.git ${ALEZ_BUILD_DIR}/iso/airootfs/usr/local/share/ALEZ 
```

Upon running `alez-downloader.sh`, it checks if the git repo exists, and runs an update if it is needed. If the repo doesn't exist it will clone it.

## Tests

* Tested local build and install with repo baked in and without.