### PR TITLE
Correct "downloading kernel version" message

### DIFF
--- a/alez.sh
+++ b/alez.sh
@@ -200,7 +200,7 @@ get_matching_kernel() {
     if [[ "${zfs_depend_ver}" != "${kernel_version}" ]]; then
 
         printf "%s\n%s\n" "zfs-linux${kern_suffix} package is out of sync with linux${kern_suffix}." \
-            "Downloading kernel ${kernel_version} from archive"
+            "Downloading kernel ${zfs_depend_ver} from archive"
 
         # Get package list
         ala="https://archive.archlinux.org/packages"


### PR DESCRIPTION
Fixes: #45

## Description
The "Downloading kernel" message that is displayed when zfs-linux kernel
is out of sync with the Arch kernel uses the wrong var in the printout.

This corrects the printout to use the version that is downloaded, rather
than the Arch kernel version.

## Testing

- [ ] Tested UEFI install to successful boot
- [ ] Tested BIOS install to successful boot

## Code

- [ ] When necessary, comments have been added in hard-to-understand areas
- [x] The changes generate no [`shellcheck`](https://github.com/koalaman/shellcheck) warnings or errors.
