### PR TITLE
Adapt ALEZ for 'base' package changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ RUN sed -i '/^\[core\]/i [archzfs]\n\
             Server = http://archzfs.com/$repo/x86_64\n' \
     "${ALEZ_BUILD_DIR}/iso/pacman.conf"
 
-RUN printf 'git\narchzfs-linux\nreflector\nwget\n' >> "${ALEZ_BUILD_DIR}/iso/packages.x86_64"
+RUN printf 'git\narchzfs-linux\nreflector\nwget\nlinux\nlinux-firmware\ndhcpcd\nless\nmdadm' >> \
+           "${ALEZ_BUILD_DIR}/iso/packages.x86_64"
+
+RUN printf '\nsystemctl enable dhcpcd' >> \
+           "${ALEZ_BUILD_DIR}/iso/airootfs/root/customize_airootfs.sh"
 
 COPY motd "${ALEZ_BUILD_DIR}/iso/airootfs/etc/"
 

--- a/alez.sh
+++ b/alez.sh
@@ -31,6 +31,11 @@ WIDTH=0
 
 show_path=false
 
+declare -a base_packages
+base_packages=(
+    'base' 'nano' 'linux-firmware' 'man-db' 'man-pages' 'vi' 'less'
+)
+
 declare -a zpool_bios_features
 zpool_bios_features=(
     'feature@lz4_compress=enabled'
@@ -245,10 +250,10 @@ install_arch(){
     echo "Installing Arch base system..."
     {
         if [[ "${kernel_type}" =~ ^(l|L)$ ]]; then
-            pacman -Sg base | cut -d ' ' -f 2 | sed 's/^linux$/linux-lts/g' | \
-                    pacstrap "${installdir}" - linux-lts-headers
+            pacstrap "${installdir}" linux-lts-headers linux-lts \
+                                     "${base_packages[@]}"
         else
-            pacstrap "${installdir}" base linux-headers
+            pacstrap "${installdir}" linux-headers linux "${base_packages[@]}"
         fi
     } 2> /dev/null
 


### PR DESCRIPTION
## Description

After the [base](https://www.archlinux.org/groups/x86_64/base/) package [change](https://www.archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/) the base package needs to be installed, and a kernel needs to be explicitly installed.

This change installed a few packages which used to be installed by default, and base. It also installs the correct kernel.

## Testing

<!--
Describe the tests that you ran. Note any details from your test configuration.
Fill any boxes [x] you have completed.
-->

- [x] Tested UEFI install to successful boot
- [x] Tested BIOS install to successful boot

## Code

- [x] When necessary, comments have been added in hard-to-understand areas
- [x] The changes generate no [`shellcheck`](https://github.com/koalaman/shellcheck) warnings or errors.
